### PR TITLE
Adding link to FINOS Privacy Policy

### DIFF
--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -11,7 +11,8 @@
       "getting-started/graph",
       "getting-started/services",
       "get-involved/terms-of-service",
-      "contribute"
+      "contribute",
+      { href: 'https://www.finos.org/privacy-policy', label: 'FINOS Privacy Policy' },
     ]
   }
 }


### PR DESCRIPTION
The new GDPR-compliant privacy policy should replace the existing privacy policy on the FINOS website and anywhere else it's publicly available.

The link is added to the leftbar menu, below the "docs" path, with label "Finos Privacy Policy", pointing to https://www.finos.org/privacy-policy