### PR TITLE
Addition of meeting minutes/action items from WG held on 16Apr

### DIFF
--- a/meeting-minutes/fx-options-wg/2020.4.16-fx-options-wg-meeting.md
+++ b/meeting-minutes/fx-options-wg/2020.4.16-fx-options-wg-meeting.md
@@ -38,3 +38,10 @@ sidebar_label: 2020.4.16
 ### AOB
 
 ### Action items
+Ted - to put together examples with Vijay (re barriers) to share with the group in the next session, particularly regarding:
+      1. buyer/seller attributes
+      2. put/callCurrencyAmount classes - representation in the CDM FxOption model. 
+Ted - to review *number* vs *float* type in CDM e.g. strike and trigger class appear as float. [21Apr - confirmed offline basicType *number* in CDM is equivalent to *float*. Vijay and team - to update in AlloyStudio.] 
+Vijay - to follow up suggestion from group around adding a function which auto-arranges a diagram.
+Vijay - to add to agenda for next session how to navigate different code formats.
+All - to have a go at modelling any suggestions in AlloyStudio and to get familiar with the tools features.


### PR DESCRIPTION
@aitana16
Action Items for Fx Option WG 16Apr20:

Ted - to put together examples with Vijay (re barriers) to share with the group in the next session, particularly regarding:
      1. buyer/seller attributes
      2. put/callCurrencyAmount classes - representation in the CDM FxOption model. 
Ted - to review *number* vs *float* type in CDM e.g. strike and trigger class appear as float. [21Apr - confirmed offline basicType *number* in CDM is equivalent to *float*. Vijay and team - to update in AlloyStudio.] 
Vijay - to follow up suggestion from group around adding a function which auto-arranges a diagram.
Vijay - to add to agenda for next session how to navigate different code formats.
All - to have a go at modelling any suggestions in AlloyStudio and to get familiar with the tools features.